### PR TITLE
Handle different response types of setCourseAttributes

### DIFF
--- a/src/scormcloud.js
+++ b/src/scormcloud.js
@@ -22,8 +22,16 @@ var SCORMCloud = function (appid, secretKey, managementid, managementKey) {
 module.exports = SCORMCloud;
 
 // Helper that wraps the given object in an array, if its not already one.
+// Returns an empty array given a falsey object, including '' which is returned
+// from the api.
 function arrayWrap(object) {
-    return Array.isArray(object) ? object : [object]
+    if (object === null || object === undefined || object === '') {
+        return []
+    } else if (_.isArray(object)) {
+        return object
+    } else {
+        return [object]
+    }
 }
 
 //
@@ -152,11 +160,9 @@ SCORMCloud.prototype.setCourseAttributes = function (courseid, attributes, callb
         // If no attributes changed we get back: `attributes: ''`
         // If one changed we get back: `attributes: { name, value }`
         // If more than one changed we get back: `attributes: [{ name, value }]`
-        if (attributes) {
-            arrayWrap(attributes).forEach(function (attribute) {
-                data[attribute.name] = getCourseAttributeValue(attribute.name, attribute.value);
-            });
-        }
+        arrayWrap(attributes).forEach(function (attribute) {
+            data[attribute.name] = getCourseAttributeValue(attribute.name, attribute.value);
+        });
 
         return callback(error, data);
 
@@ -511,7 +517,7 @@ SCORMCloud.prototype.getRegistrationListResults = function (options, callback) {
         if (error) return callback(error, json);
 
         let data = [];
-        let registrationList = _.isArray(json.rsp.registrationlist.registration) ? json.rsp.registrationlist.registration : [ json.rsp.registrationlist.registration ];
+        let registrationList = arrayWrap(json.rsp.registrationlist.registration)
 
         registrationList.forEach(function (registration) {
             data.push({

--- a/src/scormcloud.js
+++ b/src/scormcloud.js
@@ -21,6 +21,11 @@ var SCORMCloud = function (appid, secretKey, managementid, managementKey) {
 }
 module.exports = SCORMCloud;
 
+// Helper that wraps the given object in an array, if its not already one.
+function arrayWrap(object) {
+    return Array.isArray(object) ? object : [object]
+}
+
 //
 // Debug Service
 //
@@ -144,9 +149,14 @@ SCORMCloud.prototype.setCourseAttributes = function (courseid, attributes, callb
         let data = {};
         let attributes = json.rsp.attributes.attribute;
 
-        attributes.forEach(function (attribute) {
-            data[attribute.name] = getCourseAttributeValue(attribute.name, attribute.value);
-        });
+        // If no attributes changed we get back: `attributes: ''`
+        // If one changed we get back: `attributes: { name, value }`
+        // If more than one changed we get back: `attributes: [{ name, value }]`
+        if (attributes) {
+            arrayWrap(attributes).forEach(function (attribute) {
+                data[attribute.name] = getCourseAttributeValue(attribute.name, attribute.value);
+            });
+        }
 
         return callback(error, data);
 


### PR DESCRIPTION
I was getting an error

```
events.js:167
      throw er; // Unhandled 'error' event
      ^

TypeError: attributes.forEach is not a function
    at /Users/mfrawley/code/scrimmage/containers/web-activity-player/node_modules/scormcloud-api-wrapper/src/scormcloud.js:148:20
    at /Users/mfrawley/code/scrimmage/containers/web-activity-player/node_modules/scormcloud-api-wrapper/src/scormcloud.js:1653:13
    at Parser.<anonymous> (/Users/mfrawley/code/scrimmage/containers/web-activity-player/node_modules/xml2js/lib/parser.js:303:18)
    at Parser.emit (events.js:182:13)
    at SAXParser.onclosetag (/Users/mfrawley/code/scrimmage/containers/web-activity-player/node_modules/xml2js/lib/parser.js:261:26)
    at emit (/Users/mfrawley/code/scrimmage/containers/web-activity-player/node_modules/sax/lib/sax.js:624:35)
    at emitNode (/Users/mfrawley/code/scrimmage/containers/web-activity-player/node_modules/sax/lib/sax.js:629:5)
    at closeTag (/Users/mfrawley/code/scrimmage/containers/web-activity-player/node_modules/sax/lib/sax.js:889:7)
    at SAXParser.write (/Users/mfrawley/code/scrimmage/containers/web-activity-player/node_modules/sax/lib/sax.js:1436:13)
    at Parser.exports.Parser.Parser.parseString (/Users/mfrawley/code/scrimmage/containers/web-activity-player/node_modules/xml2js/lib/parser.js:322:31)
Emitted 'error' event at:
    at Parser.exports.Parser.Parser.parseString (/Users/mfrawley/code/scrimmage/containers/web-activity-player/node_modules/xml2js/lib/parser.js:326:16)
    at Parser.parseString (/Users/mfrawley/code/scrimmage/containers/web-activity-player/node_modules/xml2js/lib/parser.js:5:59)
    at exports.parseString (/Users/mfrawley/code/scrimmage/containers/web-activity-player/node_modules/xml2js/lib/parser.js:354:19)
    at Request._callback (/Users/mfrawley/code/scrimmage/containers/web-activity-player/node_modules/scormcloud-api-wrapper/src/scormcloud.js:1639:9)
    at Request.self.callback (/Users/mfrawley/code/scrimmage/containers/web-activity-player/node_modules/request/request.js:185:22)
    at Request.emit (events.js:182:13)
    at Request.<anonymous> (/Users/mfrawley/code/scrimmage/containers/web-activity-player/node_modules/request/request.js:1161:10)
    at Request.emit (events.js:182:13)
    at IncomingMessage.<anonymous> (/Users/mfrawley/code/scrimmage/containers/web-activity-player/node_modules/request/request.js:1083:12)
    at Object.onceWrapper (events.js:273:13)
```

When calling the setCourseAttributes method.  Turns out, the response differs based on how many attributes you send, and if the differed from the current value.

By adding in a `console.log(json.rsp)` I saw:


```
{ stat: 'ok',
  attributes:
   { attribute: { name: 'registrationInstancingOption', value: 'never' } } }

{ stat: 'ok', attributes: '' }


{ stat: 'ok',
  attributes: { attribute: [ [Object], [Object] ] } }
```

This PR handles each of the above.

I added a helper to deal w/ the wrapped arrays.  I could apply that to other areas in the code, or ditch its usage