### PR TITLE
Optional argument to control redirection after preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ api.authPing(function (error, result) {
 
 ### Course Service
 
-<h4 id="#getCoursePreviewUrl">.getCoursePreviewUrl(courseid, [versionid])</h4>
+<h4 id="#getCoursePreviewUrl">.getCoursePreviewUrl(courseid, [versionid, [redirectUrl]])</h4>
 
 Get the preview url for the specified course.
 
@@ -102,6 +102,10 @@ Parameters:
 
  * `courseid` - The unique identifier for the course.
  * `versionid` - The version of the package which will be used. If omitted, use the most recent version.
+ * `redirecturl` - The redirect url for when the client exits course preview. The following keywords are available:
+    * “closer” - Redirect to a page that automatically tries to close the browser window.
+    * “blank” - Redirect to a blank page.
+    * “message” - Redirect to a page with a simple message about the course being complete.
 
 ```js
 let previewUrl = api.getCoursePreviewUrl('810348d9-318e-48d5-b352-a1f6eb3a92cd');

--- a/src/scormcloud.js
+++ b/src/scormcloud.js
@@ -44,7 +44,7 @@ SCORMCloud.prototype.authPing = function (callback) {
 // Course Service
 //
 
-SCORMCloud.prototype.getCoursePreviewUrl = function (courseid, versionid) {
+SCORMCloud.prototype.getCoursePreviewUrl = function (courseid, versionid, redirecturl) {
 
     var url = new URL('api?method=rustici.course.preview', this.serviceUrl);
 
@@ -53,6 +53,9 @@ SCORMCloud.prototype.getCoursePreviewUrl = function (courseid, versionid) {
 
     // The version of the package which will be used. If omitted, use the most recent version.
     if (versionid) url.searchParams.set('versionid', versionid);
+
+    // The redirect url for when the client exits preview mode.
+    if (redirecturl) url.searchParams.set('redirecturl', redirecturl);
 
     return this._getUrl(url);
 


### PR DESCRIPTION
It would be handy to be able to provide the redirect URL for SCORM Cloud course preview URLs.